### PR TITLE
change Events description field from string to text, adapt Filament form

### DIFF
--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -41,7 +41,7 @@ class EventResource extends Resource
                     ->label('Description')
                     ->autosize()
                     ->required(),
-                    TextInput::make('meetup_link')
+                TextInput::make('meetup_link')
                     ->label('Meetup Link'),
                 Checkbox::make('is_published')
                     ->label('Is Published')

--- a/database/migrations/2025_02_08_134426_change_description_types_in_events_table.php
+++ b/database/migrations/2025_02_08_134426_change_description_types_in_events_table.php
@@ -15,5 +15,4 @@ return new class extends Migration
             $table->text('description')->change();
         });
     }
-
 };


### PR DESCRIPTION
Event Description field type was too short, changed from string to text.

Adapted Filament Event form (field order + changed description field type).