### PR TITLE
Add ULID columns to domain models

### DIFF
--- a/app/Console/Commands/BackfillUlids.php
+++ b/app/Console/Commands/BackfillUlids.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\Post;
+use App\Models\Speaker;
+use App\Models\Sponsor;
+use App\Models\Talk;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class BackfillUlids extends Command
+{
+    protected $signature = 'ulids:backfill';
+
+    protected $description = 'Backfill ULIDs for existing records that are missing one.';
+
+    /** @var array<int, class-string<Model>> */
+    private array $models = [
+        Event::class,
+        Location::class,
+        Post::class,
+        Speaker::class,
+        Sponsor::class,
+        Talk::class,
+    ];
+
+    public function handle(): int
+    {
+        foreach ($this->models as $modelClass) {
+            $count = 0;
+
+            $modelClass::query()
+                ->whereNull('ulid')
+                ->each(function (Model $record) use (&$count): void {
+                    $record->ulid = (string) Str::ulid();
+                    $record->saveQuietly();
+                    $count++;
+                });
+
+            $this->info("{$modelClass}: backfilled {$count} record(s).");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/BackfillUlids.php
+++ b/app/Console/Commands/BackfillUlids.php
@@ -10,7 +10,6 @@ use App\Models\Sponsor;
 use App\Models\Talk;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
 
 class BackfillUlids extends Command
 {
@@ -36,12 +35,12 @@ class BackfillUlids extends Command
             $modelClass::query()
                 ->whereNull('ulid')
                 ->each(function (Model $record) use (&$count): void {
-                    $record->setAttribute('ulid', (string) Str::ulid());
+                    $record->setAttribute('ulid', $record->newUniqueId());
                     $record->saveQuietly();
                     $count++;
                 });
 
-            $this->info("{$modelClass}: backfilled {$count} record(s).");
+            $this->info(class_basename($modelClass).": backfilled {$count} record(s).");
         }
 
         return self::SUCCESS;

--- a/app/Console/Commands/BackfillUlids.php
+++ b/app/Console/Commands/BackfillUlids.php
@@ -36,7 +36,7 @@ class BackfillUlids extends Command
             $modelClass::query()
                 ->whereNull('ulid')
                 ->each(function (Model $record) use (&$count): void {
-                    $record->ulid = (string) Str::ulid();
+                    $record->setAttribute('ulid', (string) Str::ulid());
                     $record->saveQuietly();
                     $count++;
                 });

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Override;
+use RalphJSmit\Laravel\SEO\Models\SEO;
 use RalphJSmit\Laravel\SEO\Support\HasSEO;
 use RalphJSmit\Laravel\SEO\Support\SEOData;
 
@@ -30,7 +31,11 @@ use RalphJSmit\Laravel\SEO\Support\SEOData;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property int|null $location_id
+ * @property string|null $ulid
  * @property-read Location|null $location
+ * @property-read CarbonPeriodImmutable $period
+ * @property-read SEO $seo
+ * @property-read string $show_url
  * @property-read Collection<int, Talk> $talks
  * @property-read int|null $talks_count
  *
@@ -51,6 +56,7 @@ use RalphJSmit\Laravel\SEO\Support\SEOData;
  * @method static EventBuilder<static>|Event whereMeetupLink($value)
  * @method static EventBuilder<static>|Event whereName($value)
  * @method static EventBuilder<static>|Event whereStartDate($value)
+ * @method static EventBuilder<static>|Event whereUlid($value)
  * @method static EventBuilder<static>|Event whereUpdatedAt($value)
  *
  * @mixin \Eloquent

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -8,6 +8,7 @@ use Carbon\CarbonPeriodImmutable;
 use Database\Factories\EventFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -60,6 +61,17 @@ class Event extends Model
     use HasFactory;
 
     use HasSEO;
+    use HasUlids;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 
     /**
      * @return EventBuilder<Event>

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Carbon;
  * @property int|null $capacity
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property string|null $ulid
  *
  * @method static \Database\Factories\LocationFactory factory($count = null, $state = [])
  * @method static Builder<static>|Location newModelQuery()
@@ -33,6 +34,7 @@ use Illuminate\Support\Carbon;
  * @method static Builder<static>|Location whereId($value)
  * @method static Builder<static>|Location whereName($value)
  * @method static Builder<static>|Location whereNotes($value)
+ * @method static Builder<static>|Location whereUlid($value)
  * @method static Builder<static>|Location whereUpdatedAt($value)
  * @method static Builder<static>|Location whereZipCode($value)
  *

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Database\Factories\LocationFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -41,4 +42,16 @@ class Location extends Model
 {
     /** @use HasFactory<LocationFactory> */
     use HasFactory;
+
+    use HasUlids;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 }

--- a/app/Models/NewsletterSubscriber.php
+++ b/app/Models/NewsletterSubscriber.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  *
+ * @method static \Database\Factories\NewsletterSubscriberFactory factory($count = null, $state = [])
  * @method static Builder<static>|NewsletterSubscriber newModelQuery()
  * @method static Builder<static>|NewsletterSubscriber newQuery()
  * @method static Builder<static>|NewsletterSubscriber query()

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -7,6 +7,7 @@ use Database\Factories\PostFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -54,6 +55,17 @@ class Post extends Model
 
     use HasSEO;
     use HasSlug;
+    use HasUlids;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 
     protected function casts(): array
     {

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -28,6 +28,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property CarbonImmutable|null $published_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property string|null $ulid
  * @property-read Collection<int, User> $authors
  * @property-read int|null $authors_count
  * @property-read mixed $parsed_content
@@ -44,6 +45,7 @@ use Spatie\Sluggable\SlugOptions;
  * @method static Builder<static>|Post wherePublishedAt($value)
  * @method static Builder<static>|Post whereSlug($value)
  * @method static Builder<static>|Post whereTitle($value)
+ * @method static Builder<static>|Post whereUlid($value)
  * @method static Builder<static>|Post whereUpdatedAt($value)
  *
  * @mixin \Eloquent

--- a/app/Models/Speaker.php
+++ b/app/Models/Speaker.php
@@ -23,9 +23,11 @@ use Illuminate\Support\Carbon;
  * @property string|null $youtube_profile
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property string|null $ulid
  * @property-read Collection<int, Talk> $talks
  * @property-read int|null $talks_count
  *
+ * @method static \Database\Factories\SpeakerFactory factory($count = null, $state = [])
  * @method static Builder<static>|Speaker newModelQuery()
  * @method static Builder<static>|Speaker newQuery()
  * @method static Builder<static>|Speaker query()
@@ -36,6 +38,7 @@ use Illuminate\Support\Carbon;
  * @method static Builder<static>|Speaker whereId($value)
  * @method static Builder<static>|Speaker whereLinkedinProfile($value)
  * @method static Builder<static>|Speaker whereName($value)
+ * @method static Builder<static>|Speaker whereUlid($value)
  * @method static Builder<static>|Speaker whereUpdatedAt($value)
  * @method static Builder<static>|Speaker whereWebsite($value)
  * @method static Builder<static>|Speaker whereXProfile($value)

--- a/app/Models/Speaker.php
+++ b/app/Models/Speaker.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Database\Factories\SpeakerFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -46,6 +47,18 @@ class Speaker extends Model
 {
     /** @use HasFactory<SpeakerFactory> */
     use HasFactory;
+
+    use HasUlids;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 
     /**
      * @return BelongsToMany<Talk, $this>

--- a/app/Models/Sponsor.php
+++ b/app/Models/Sponsor.php
@@ -24,6 +24,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property string|null $background_color
+ * @property string|null $ulid
  * @property-read MediaCollection<int, Media> $media
  * @property-read int|null $media_count
  *
@@ -39,6 +40,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
  * @method static SponsorBuilder<static>|Sponsor whereName($value)
  * @method static SponsorBuilder<static>|Sponsor whereOrder($value)
  * @method static SponsorBuilder<static>|Sponsor whereType($value)
+ * @method static SponsorBuilder<static>|Sponsor whereUlid($value)
  * @method static SponsorBuilder<static>|Sponsor whereUpdatedAt($value)
  * @method static SponsorBuilder<static>|Sponsor whereWebsite($value)
  *

--- a/app/Models/Sponsor.php
+++ b/app/Models/Sponsor.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Builders\SponsorBuilder;
 use App\Enums\SponsorType;
 use Database\Factories\SponsorFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -48,7 +49,18 @@ class Sponsor extends Model implements HasMedia
     /** @use HasFactory<SponsorFactory> */
     use HasFactory;
 
+    use HasUlids;
     use InteractsWithMedia;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 
     protected function casts(): array
     {

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -18,11 +18,13 @@ use Illuminate\Support\Carbon;
  * @property string|null $recording_url
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property string|null $ulid
  * @property-read Collection<int, Event> $events
  * @property-read int|null $events_count
  * @property-read Collection<int, Speaker> $speakers
  * @property-read int|null $speakers_count
  *
+ * @method static \Database\Factories\TalkFactory factory($count = null, $state = [])
  * @method static Builder<static>|Talk newModelQuery()
  * @method static Builder<static>|Talk newQuery()
  * @method static Builder<static>|Talk query()
@@ -31,6 +33,7 @@ use Illuminate\Support\Carbon;
  * @method static Builder<static>|Talk whereId($value)
  * @method static Builder<static>|Talk whereRecordingUrl($value)
  * @method static Builder<static>|Talk whereTitle($value)
+ * @method static Builder<static>|Talk whereUlid($value)
  * @method static Builder<static>|Talk whereUpdatedAt($value)
  *
  * @mixin \Eloquent

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Database\Factories\TalkFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -38,6 +39,18 @@ class Talk extends Model
 {
     /** @use HasFactory<TalkFactory> */
     use HasFactory;
+
+    use HasUlids;
+
+    /**
+     * Get the columns that should receive a unique identifier.
+     *
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['ulid'];
+    }
 
     /**
      * @return BelongsToMany<Speaker, $this>

--- a/database/migrations/2026_07_02_144536_add_ulid_to_tables.php
+++ b/database/migrations/2026_07_02_144536_add_ulid_to_tables.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /** @var array<int, string> */
+    private array $tables = ['events', 'locations', 'posts', 'speakers', 'sponsors', 'talks'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->ulid('ulid')->nullable()->unique()->after('id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->dropUnique(['ulid']);
+                $table->dropColumn('ulid');
+            });
+        }
+    }
+};

--- a/tests/Feature/Console/BackfillUlidsTest.php
+++ b/tests/Feature/Console/BackfillUlidsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Event;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+it('backfills a ulid for rows that are missing one', function (): void {
+    // Create an event via factory to get valid data, but insert directly to skip ULID generation
+    $data = Event::factory()->make()->toArray();
+    unset($data['created_at'], $data['updated_at']); // Remove timestamps, they'll be added by DB
+    DB::table('events')->insert([...$data, 'created_at' => now(), 'updated_at' => now()]);
+
+    $event = Event::latest('id')->first();
+    expect($event->ulid)->toBeNull();
+
+    $this->artisan('ulids:backfill')->assertSuccessful();
+
+    $ulid = $event->fresh()->ulid;
+    expect($ulid)->not->toBeNull()
+        ->and(Str::isUlid($ulid))->toBeTrue();
+});
+
+it('leaves existing ulids untouched', function (): void {
+    $event = Event::factory()->create();
+    $originalUlid = $event->ulid;
+
+    $this->artisan('ulids:backfill')->assertSuccessful();
+
+    expect($event->fresh()->ulid)->toBe($originalUlid);
+});

--- a/tests/Feature/Console/BackfillUlidsTest.php
+++ b/tests/Feature/Console/BackfillUlidsTest.php
@@ -17,7 +17,8 @@ it('backfills a ulid for rows that are missing one', function (): void {
 
     $ulid = $event->fresh()->ulid;
     expect($ulid)->not->toBeNull()
-        ->and(Str::isUlid($ulid))->toBeTrue();
+        ->and(Str::isUlid($ulid))->toBeTrue()
+        ->and($ulid)->toBe(strtolower($ulid));
 });
 
 it('leaves existing ulids untouched', function (): void {

--- a/tests/Feature/Models/HasUlidTest.php
+++ b/tests/Feature/Models/HasUlidTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Event;
+use App\Models\Location;
+use App\Models\Post;
+use App\Models\Speaker;
+use App\Models\Sponsor;
+use App\Models\Talk;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+/** @return array<int, class-string<Model>> */
+function ulidModels(): array
+{
+    return [Event::class, Location::class, Post::class, Speaker::class, Sponsor::class, Talk::class];
+}
+
+it('generates a valid ulid when creating a model', function (string $modelClass): void {
+    $model = $modelClass::factory()->create();
+
+    expect($model->ulid)->not->toBeNull()
+        ->and(Str::isUlid($model->ulid))->toBeTrue();
+})->with(ulidModels());
+
+it('keeps the integer primary key auto-incrementing', function (string $modelClass): void {
+    $model = $modelClass::factory()->create();
+
+    expect($model->getIncrementing())->toBeTrue()
+        ->and($model->getKeyType())->toBe('int')
+        ->and($model->id)->toBeInt();
+})->with(ulidModels());
+
+it('preserves a manually provided ulid', function (): void {
+    $ulid = (string) Str::ulid();
+    $event = Event::factory()->create(['ulid' => $ulid]);
+
+    expect($event->ulid)->toBe($ulid);
+});

--- a/tests/Feature/UlidMigrationTest.php
+++ b/tests/Feature/UlidMigrationTest.php
@@ -5,3 +5,19 @@ use Illuminate\Support\Facades\Schema;
 it('adds a ulid column to the domain tables', function (string $table): void {
     expect(Schema::hasColumn($table, 'ulid'))->toBeTrue();
 })->with(['events', 'locations', 'posts', 'speakers', 'sponsors', 'talks']);
+
+it('ulid column is nullable on domain tables', function (string $table): void {
+    $columns = Schema::getColumns($table);
+    $ulidColumn = collect($columns)->firstWhere('name', 'ulid');
+
+    expect($ulidColumn)->not->toBeNull();
+    expect($ulidColumn['nullable'])->toBeTrue();
+})->with(['events', 'locations', 'posts', 'speakers', 'sponsors', 'talks']);
+
+it('ulid column has unique index on domain tables', function (string $table): void {
+    $indexes = Schema::getIndexes($table);
+    $ulidIndex = collect($indexes)->first(fn ($index) => $index['columns'] === ['ulid']);
+
+    expect($ulidIndex)->not->toBeNull();
+    expect($ulidIndex['unique'])->toBeTrue();
+})->with(['events', 'locations', 'posts', 'speakers', 'sponsors', 'talks']);

--- a/tests/Feature/UlidMigrationTest.php
+++ b/tests/Feature/UlidMigrationTest.php
@@ -16,7 +16,7 @@ it('ulid column is nullable on domain tables', function (string $table): void {
 
 it('ulid column has unique index on domain tables', function (string $table): void {
     $indexes = Schema::getIndexes($table);
-    $ulidIndex = collect($indexes)->first(fn ($index) => $index['columns'] === ['ulid']);
+    $ulidIndex = collect($indexes)->first(fn ($index): bool => $index['columns'] === ['ulid']);
 
     expect($ulidIndex)->not->toBeNull();
     expect($ulidIndex['unique'])->toBeTrue();

--- a/tests/Feature/UlidMigrationTest.php
+++ b/tests/Feature/UlidMigrationTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+
+it('adds a ulid column to the domain tables', function (string $table): void {
+    expect(Schema::hasColumn($table, 'ulid'))->toBeTrue();
+})->with(['events', 'locations', 'posts', 'speakers', 'sponsors', 'talks']);


### PR DESCRIPTION
## Summary

Adds a secondary `ulid` identifier to the six domain models while **keeping the integer `id` as the primary key** (per request — integer IDs stay for now). The ULID is an additional, unique, lexicographically-sortable column.

**Models in scope:** `Event`, `Location`, `Post`, `Speaker`, `Sponsor`, `Talk`. Out of scope: `User`, `NewsletterSubscriber`, pivot tables, and package tables.

## What changed

- **Migration** — adds a `nullable`, `unique` `ulid` column (`after('id')`) to the six tables. `down()` reverses cleanly (verified on SQLite).
- **`HasUlids` trait** — each model uses Laravel's own `Illuminate\Database\Eloquent\Concerns\HasUlids` with `uniqueIds()` overridden to `['ulid']`. Because `id` isn't in `uniqueIds()`, the integer auto-increment primary key and route-model-binding are left fully intact; only the `ulid` column is auto-generated on creation.
- **`ulids:backfill` command** — fills existing rows where `ulid` is null, saving quietly (no `updated_at` churn) and leaving existing ulids untouched. Iterates via `each()` (chunks by immutable PK — memory-safe and idempotent). Uses `$record->newUniqueId()` so backfilled ULIDs match the (lowercase) casing of model-created ones.
- **Annotations** — regenerated model docblocks (`composer refactor:annotate`).

## Testing

`composer test:pest` green (115 tests). New coverage:
- Migration: column exists, is nullable, has a unique index (all six tables)
- Trait: ULID generated on create, integer PK preserved (`getIncrementing()`/`getKeyType()`), manually-set ULID preserved
- Command: null-ulid rows backfilled with a valid **lowercase** ULID; existing ulids untouched

> Note: PHPStan and Rector report pre-existing, unrelated failures on this repo; this branch introduces no new type/style findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)